### PR TITLE
Fix bug when accessing autosaved association within transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.1.0 2019-02-07
+
+### Compatible changes
+
+- Fix bug when accessing autosaved association within transition
+
 ## 1.0.0 2018-09-04
 
 ### Compatible changes

--- a/Gemfile.5.1.pg.lock
+++ b/Gemfile.5.1.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_state_machine (1.0.0)
+    rails_state_machine (1.1.0)
       activerecord
 
 GEM
@@ -146,4 +146,4 @@ DEPENDENCIES
   rspec (~> 3.5)
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/Gemfile.5.2.pg.lock
+++ b/Gemfile.5.2.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_state_machine (0.1.0)
+    rails_state_machine (1.1.0)
       activerecord
 
 GEM
@@ -154,4 +154,4 @@ DEPENDENCIES
   rspec (~> 3.5)
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/lib/rails_state_machine/state_machine.rb
+++ b/lib/rails_state_machine/state_machine.rb
@@ -182,15 +182,20 @@ module RailsStateMachine
             after_save: [],
             after_commit: []
           }
-          @state_event_callbacks[:before_save] << @next_state_machine_event
-          @state_event_callbacks[:after_save] << @next_state_machine_event
-          @state_event_callbacks[:after_commit] << @next_state_machine_event
+          if @next_state_machine_event
+            @state_event_callbacks[:before_save] << @next_state_machine_event
+            @state_event_callbacks[:after_save] << @next_state_machine_event
+            @state_event_callbacks[:after_commit] << @next_state_machine_event
+          end
+
           true
         end
 
         def flush_state_event_callbacks(name)
-          while (event = @state_event_callbacks[name].shift)
-            event.public_send("run_#{name}", self)
+          if @state_event_callbacks
+            while (event = @state_event_callbacks[name].shift)
+              event.public_send("run_#{name}", self)
+            end
           end
         end
 

--- a/lib/rails_state_machine/version.rb
+++ b/lib/rails_state_machine/version.rb
@@ -1,3 +1,3 @@
 module RailsStateMachine
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/rails_state_machine/model_spec.rb
+++ b/spec/rails_state_machine/model_spec.rb
@@ -10,7 +10,7 @@ describe RailsStateMachine::Model do
 
   describe '.state_events' do
     it 'returns the list of available state events' do
-      expect(parcel_class.state_events).to eq([:pack, :pack_and_ship, :ship])
+      expect(parcel_class.state_events).to eq([:destroy_content, :pack, :pack_and_ship, :ship])
     end
   end
 

--- a/spec/rails_state_machine/state_machine_spec.rb
+++ b/spec/rails_state_machine/state_machine_spec.rb
@@ -17,4 +17,14 @@ describe RailsStateMachine::StateMachine do
     end
   end
 
+  describe '#destroy_content' do
+    it 'does not crash while accessing the parcel_content association within a state transition' do
+      parcel = Parcel.create!
+      parcel.build_parcel_content.save!
+
+      parcel = Parcel.first
+      expect { parcel.destroy_content! && parcel.reload.parcel_content }.to_not raise_error
+    end
+  end
+
 end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -10,4 +10,9 @@ database.rewrite_schema! do
     t.datetime :shipped_at
   end
 
+  create_table :parcel_contents do |t|
+    t.integer :parcel_id
+    t.string :state
+  end
+
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,6 +1,8 @@
 class Parcel < ActiveRecord::Base
   include RailsStateMachine::Model
 
+  has_one :parcel_content, autosave: true
+
   before_validation { callbacks.push('before_validation (model)') }
   before_save { callbacks.push('before_save (model)') }
   after_save { callbacks.push('after_save (model)') }
@@ -12,6 +14,14 @@ class Parcel < ActiveRecord::Base
     state :empty, initial: true
     state :filled
     state :shipped
+
+    event :destroy_content do
+      transitions from: :empty, to: :empty
+
+      after_save do
+        parcel_content&.destroy!
+      end
+    end
 
     event :pack do
       transitions from: :empty, to: :filled
@@ -43,5 +53,15 @@ class Parcel < ActiveRecord::Base
 
   def callbacks
     @callbacks ||= []
+  end
+end
+
+class ParcelContent < ActiveRecord::Base
+  include RailsStateMachine::Model
+
+  belongs_to :parcel
+
+  state_machine do
+    state :empty, initial: true
   end
 end


### PR DESCRIPTION
Some details about this:

Within `state_machine.rb:185` / `def flush_state_event_callbacks`:
`@state_event_callbacks` is empty when accessing an association beeing saved through Rails' `autosave: true` feature because the `register_state_events_for_callbacks` method never gets called.

In the combination described above, Rails skips `before_save` and `before_validation` callbacks and only runs `after_commit`.