### PR TITLE
Add support for multiple state machines with different state names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,17 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### Breaking changes
-
--
+## Unreleased (might warrant major update)
 
 ### Compatible changes
 
--
+- Added: State machine can now use an attribute other than `state` to represent the machine's state.
+- Added: It is now possible to define multiple state machines on the same model.
+
+### Breaking changes
+
+- Removed: Dropped support for adding a state machine without including `RailsStateMachine::Model`.
+
 
 ## 1.1.3 2019-08-12
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ end
 ```
 
 This also allows you to define multiple state machines on the same model. Note that event
-names still ahve to be unique for the whole model.
+names still have to be unique for the whole model.
 
 
 ## Taking multiple transitions

--- a/lib/rails_state_machine.rb
+++ b/lib/rails_state_machine.rb
@@ -1,5 +1,7 @@
 require 'rails_state_machine/version'
 require 'rails_state_machine/state'
 require 'rails_state_machine/event'
+require 'rails_state_machine/callbacks'
 require 'rails_state_machine/state_machine'
+require 'rails_state_machine/state_manager'
 require 'rails_state_machine/model'

--- a/lib/rails_state_machine/callbacks.rb
+++ b/lib/rails_state_machine/callbacks.rb
@@ -1,0 +1,68 @@
+module RailsStateMachine
+  module Callbacks
+    class << self
+      def included(model)
+        register_callbacks(model)
+        register_validations(model)
+      end
+
+      private
+
+      def register_callbacks(model)
+        model.class_eval do
+          before_validation :run_state_events_before_validation
+          before_save :register_state_events_for_callbacks
+          before_save { flush_state_event_callbacks(:before_save) }
+          after_save { flush_state_event_callbacks(:after_save) }
+          after_commit { flush_state_event_callbacks(:after_commit) }
+        end
+      end
+
+      def register_validations(model)
+        model.class_eval do
+          after_validation :revert_states, if: -> { errors.any? }
+        end
+      end
+    end
+
+    def run_state_events_before_validation
+      # Since validations may be skipped, we will not register validation callbacks in @state_event_callbacks,
+      # but call them explicitly when before_validation callbacks are triggered.
+      state_machine_state_managers.each do |state_manager|
+        state_manager.next_event&.run_before_validation(self)
+      end
+    end
+
+    def register_state_events_for_callbacks
+      @state_event_callbacks ||= {
+        before_save: [],
+        after_save: [],
+        after_commit: []
+      }
+      state_machine_state_managers.each do |state_manager|
+        if (next_event = state_manager.next_event)
+          @state_event_callbacks[:before_save] << next_event
+          @state_event_callbacks[:after_save] << next_event
+          @state_event_callbacks[:after_commit] << next_event
+          state_manager.next_event = nil
+        end
+      end
+
+      true
+    end
+
+    def flush_state_event_callbacks(name)
+      if @state_event_callbacks
+        while (event = @state_event_callbacks[name].shift)
+          event.public_send("run_#{name}", self)
+        end
+      end
+    end
+
+    def revert_states
+      state_machine_state_managers.each do |state_manager|
+        state_manager.revert
+      end
+    end
+  end
+end

--- a/lib/rails_state_machine/model.rb
+++ b/lib/rails_state_machine/model.rb
@@ -1,21 +1,69 @@
 module RailsStateMachine
+  DEFAULT_STATE_ATTRIBUTE = :state
+
   module Model
     def self.included(base)
-      base.extend ClassMethods
+      base.class_eval do
+        extend ClassMethods
+
+        cattr_accessor :state_machines
+        self.state_machines = {}
+
+        delegate :state_machine, to: :class
+      end
     end
 
     module ClassMethods
-      def state_machine(&block)
-        StateMachine.new(self).configure(&block)
+      def state_machine(state_attribute = DEFAULT_STATE_ATTRIBUTE, &block)
+        include(Callbacks)
+        state_machine = state_machines[state_attribute] ||= StateMachine.new(self, state_attribute)
+        state_machine.configure(&block) if block
+        state_machine
       end
 
-      def states
-        state_machine.state_names
+      def states(state_attribute = DEFAULT_STATE_ATTRIBUTE)
+        state_machine(state_attribute).state_names
       end
 
-      def state_events
-        state_machine.event_names
+      def state_events(state_attribute = DEFAULT_STATE_ATTRIBUTE)
+        state_machine(state_attribute).event_names
       end
+    end
+
+
+    private
+
+    def state_machine_state_manager(state_attribute)
+      @state_machine_state_managers ||= {}
+      @state_machine_state_managers[state_attribute] ||= StateManager.new(self, state_machine(state_attribute), state_attribute)
+    end
+
+    def state_machine_state_managers
+      self.state_machines.keys.collect do |state_attribute|
+        state_machine_state_manager(state_attribute)
+      end
+    end
+
+    def prepare_state_event_change(attributes)
+      if ActiveRecord::VERSION::STRING < '5.2' && saved_changes?
+        # After calling `save`, ActiveRecord 5.1 will flag the changes that it just stored as saved.
+        # https://github.com/rails/rails/blob/v5.1.4/activerecord/lib/active_record/attribute_methods/dirty.rb#L33-L46
+        #
+        # When taking multiple state events (e.g. a second event called inside an `after_save` callback) and thus
+        # saving after other changes were just saved, we need to mimic that behavior. Otherwise, ActiveRecord will
+        # print deprecation warnings like these:
+        #
+        #     DEPRECATION WARNING: The behavior of `attribute_was` inside of after callbacks will be changing in the
+        #     next version of Rails. The new return value will reflect the behavior of calling the method after
+        #     `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use
+        #     `attribute_before_last_save` instead.
+        #
+        # These actually originate from ActiveRecord internals which try to determine the changes that should be
+        # stored for the second save. It is probably a shortcoming of ActiveRecord 5.1.x that will be fixed, but
+        # since the current/previous save was already successful, the right action is to just call `changes_applied`.
+        changes_applied
+      end
+      self.attributes = attributes
     end
   end
 end

--- a/lib/rails_state_machine/model.rb
+++ b/lib/rails_state_machine/model.rb
@@ -15,9 +15,11 @@ module RailsStateMachine
 
     module ClassMethods
       def state_machine(state_attribute = DEFAULT_STATE_ATTRIBUTE, &block)
-        include(Callbacks)
         state_machine = state_machines[state_attribute] ||= StateMachine.new(self, state_attribute)
-        state_machine.configure(&block) if block
+        if block
+          include(Callbacks) unless self < Callbacks
+          state_machine.configure(&block)
+        end
         state_machine
       end
 

--- a/lib/rails_state_machine/state_machine.rb
+++ b/lib/rails_state_machine/state_machine.rb
@@ -1,5 +1,7 @@
 module RailsStateMachine
   class StateMachine
+    attr_reader :model
+
     def initialize(model, state_attribute)
       @model = model
       @state_attribute = state_attribute

--- a/lib/rails_state_machine/state_manager.rb
+++ b/lib/rails_state_machine/state_manager.rb
@@ -1,0 +1,47 @@
+module RailsStateMachine
+  class StateManager
+    attr_accessor :next_event, :state_before_state_event
+
+    def initialize(record, state_machine, state_attribute)
+      @record = record
+      @state_machine = state_machine
+      @state_attribute = state_attribute
+    end
+
+    def state
+      @record.public_send(@state_attribute)
+    end
+
+    def state_in_database
+      @record.public_send(:"#{@state_attribute}_in_database").to_s
+    end
+
+    def state=(value)
+      @record.public_send(:"#{@state_attribute}=", value)
+    end
+
+    def revert
+      self.state = @state_before_state_event if @next_event
+    end
+
+    def source_state
+      if @record.new_record?
+        state
+      else
+        state_in_database
+      end
+    end
+
+    def transition_to(event_name)
+      @next_event = @state_machine.find_event(event_name)
+      @state_before_state_event = source_state
+
+      # If the event can not transition from source_state, a TransitionNotFoundError will be raised
+      self.state = @next_event.future_state_name(source_state).to_s
+    end
+
+    def transition_allowed_for?(event_name)
+      @state_machine.find_event(event_name).allowed_from?(source_state)
+    end
+  end
+end

--- a/spec/rails_state_machine/model_spec.rb
+++ b/spec/rails_state_machine/model_spec.rb
@@ -14,4 +14,16 @@ describe RailsStateMachine::Model do
     end
   end
 
+  describe '.state_machine' do
+    it 'registered necessary callbacks only once (BUGFIX)' do
+      expect(RailsStateMachine::Callbacks).to receive(:included).exactly(:once)
+      class_with_machine = Class.new(ActiveRecord::Base) do
+        include RailsStateMachine::Model
+        state_machine(:foo) {}
+        state_machine(:bar) {}
+      end
+      expect(class_with_machine < RailsStateMachine::Callbacks).to eq true
+    end
+  end
+
 end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -5,6 +5,7 @@ database.rewrite_schema! do
 
   create_table :parcels do |t|
     t.string :state
+    t.string :payment_state
     t.string :shipment_tracking
     t.integer :weight
     t.datetime :shipped_at

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -56,6 +56,33 @@ class Parcel < ActiveRecord::Base
     end
   end
 
+  state_machine(:payment_state) do
+    state :pending, initial: true
+    state :paid
+    state :failed
+
+    event :payment_succeeds do
+      transitions from: :pending, to: :paid
+
+      before_save do
+        callbacks.push('before_save for payment_succeeds (state machine)')
+      end
+
+      after_save do
+        callbacks.push('after_save for payment_succeeds (state machine)')
+        pack_and_ship
+      end
+
+      after_commit do
+        callbacks.push('after_commit for payment_succeeds (state machine)')
+      end
+    end
+
+    event :payment_fails do
+      transitions from: :pending, to: :failed
+    end
+  end
+
   def callbacks
     @callbacks ||= []
   end


### PR DESCRIPTION
I've needed to have more than one state machine within a single model, and ended up adding support to the gem.

Unfortunately, this required a relatively big refactoring, and the code certainly did not get simpler by this.