### PR TITLE
Stop discarding unsaved changes on Rails 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Compatible changes
+
+- Fix a bug sometimes causing unsaved changes to be lost on state transitions.
+
 ## 1.1.2 2019-03-22
 
 ### Compatible changes

--- a/lib/rails_state_machine/state_machine.rb
+++ b/lib/rails_state_machine/state_machine.rb
@@ -209,8 +209,8 @@ module RailsStateMachine
         end
 
         def prepare_state_event_change(attributes)
-          if saved_changes?
-            # After calling `save`, ActiveRecord will flag the changes that it just stored as saved.
+          if ActiveRecord::VERSION::STRING <= '5.2' && saved_changes?
+            # After calling `save`, ActiveRecord 5.1 will flag the changes that it just stored as saved.
             # https://github.com/rails/rails/blob/v5.1.4/activerecord/lib/active_record/attribute_methods/dirty.rb#L33-L46
             #
             # When taking multiple state events (e.g. a second event called inside an `after_save` callback) and thus

--- a/spec/rails_state_machine/state_machine/event_spec.rb
+++ b/spec/rails_state_machine/state_machine/event_spec.rb
@@ -127,4 +127,11 @@ describe RailsStateMachine::StateMachine do
     end
   end
 
+  it 'does not lose unsaved changes on models that have been saved before (BUGFIX)' do
+    parcel = Parcel.create!(weight: 1)
+    parcel.weight = 2
+    parcel.pack!
+    expect(parcel.reload.weight).to eq 2
+  end
+
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -49,6 +49,8 @@ class Parcel < ActiveRecord::Base
     event :ship do
       transitions from: :filled, to: :shipped
 
+      before_save { weight_was } # trigger deprecation warning in Rails 5.1 without our workaround
+
       after_save { callbacks.push('after_save for ship (state machine)') }
       after_commit { callbacks.push('after_commit for ship (state machine)') }
     end


### PR DESCRIPTION
The code contains a hack that suppresses deprecation warnings when doing something like

```
state_machine do
  event :transition1 do
    after_save do
      transition2!
    end
  end

  event transition2 do
    before_save do
      some_attribute_was  # will trigger a deprecation warning about the use of ..._was in after_save callbacks
    end
  end
end
```

Unfortunately, in Rails 5.2 (but not 5.1) this causes unsaved changes to be lost on state transitions:

```
record.save! # unrelated save berfore
record.some_attribute = 'new value'
record.transition! # this will save the new state, but not `some_attribute`
```

Fortunately, the hack is not even required in Rails 5.2, so a simple version switch will solve both issues..