### PR TITLE
Fix error "undefined method '[]' for nil"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Compatible changes
--
+- Fix error "undefined method `[]' for nil" due to missing code line in previous version
 
 ### Breaking changes
 -

--- a/lib/rails_state_machine/model.rb
+++ b/lib/rails_state_machine/model.rb
@@ -36,6 +36,7 @@ module RailsStateMachine
     private
 
     def state_machine_state_manager(state_attribute)
+      @state_machine_state_managers ||= {}
       @state_machine_state_managers[state_attribute] ||= StateManager.new(self, state_machine(state_attribute), state_attribute)
     end
 


### PR DESCRIPTION
After upgrading an application to the current latest version of rails_state_machine (`3.1.1`) and running my specs, I encountered a lot of errors `undefined method '[]' for nil` when running the application's specs. 

This seems to be caused by the removal of the line `@state_machine_state_managers ||= {}` in `model.rb` in the previous version. After creating a model with a state machine through factory bot, the test crashes with the given error message. 

After adding the previously removed line of code back in, all my tests are passing as expected.